### PR TITLE
Added pull from url functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -440,14 +440,36 @@
 
 
     /* come from sharing */
-    if (location.hash.length > 1) {
-      editor.getSession().setValue(decodeURIComponent(location.hash.substring(1)));
-    }
+		const params = new URLSearchParams(location.search.substring(1));
+		if (params.has('raw')) {
+			editor.getSession().setValue(params.get('raw'));
+      renderGraph();
+		} else if (params.has('compressed')) {
+			const compressed = params.get('compressed');
+		} else if (params.has('url')) {
+			const url = params.get('url');
+			let ok = false;
+			fetch(url)
+				.then(res => {
+					ok = res.ok;
+					return res.text();
+				})
+				.then(res => {
+					if (!ok) {
+						throw { message: res };
+					}
 
-    /* Init */
-    if (editor.getValue()) {
+					editor.getSession().setValue(res);
+					renderGraph();
+				}).catch(e => {
+					show_error(e);
+				});
+		} else if (location.hash.length > 1) {
+      editor.getSession().setValue(decodeURIComponent(location.hash.substring(1)));
+		} else if (editor.getValue()) { // Init
       renderGraph();
     }
+
   })(document);
 </script>
 <script src="viz.js" type="text/javascript" charset="utf-8"></script>


### PR DESCRIPTION
Should (hopefully) resolve #12. 

The page now checks the querystring (if it exists) for parameters to pull, in order of priority:

1.  `raw`, basically the same as the existing hash system.
2. `compressed`, as described by @leonelgalan. I haven't actually implemented this since it requires importing a library.
3. `url`, pulls the data from the provided url, assuming the content is served as raw text.

It then falls back to the existing hash scheme is these parameters are not present.

I don't think trying to bypass CORS is the right way to go, especially since gists support CORS, along with any other service that one might use for such a purpose. JSONP is pretty much running arbitrary scripts, which is fairly distasteful to me.