### PR TITLE
use Workaround for loading page on local disk 

### DIFF
--- a/full.render.js
+++ b/full.render.js
@@ -1,3 +1,6 @@
+//Workaround for loading page on local disk from https://stackoverflow.com/questions/21408510/chrome-cant-load-web-worker
+function worker_function() {
+
 /*
 Viz.js 2.1.1 (Graphviz 2.40.1, Expat 2.2.5, Emscripten 1.37.36)
 */
@@ -85,3 +88,12 @@ if (typeof global.Viz !== 'undefined') {
 }
 
 })(typeof self !== 'undefined' ? self : this);
+    
+}
+// This is in case of normal worker start
+// "window" is not defined in web worker
+// so if you load this file directly using `new Worker`
+// the worker code will still execute properly
+//see: Workaround for loading page on local disk from https://stackoverflow.com/questions/21408510/chrome-cant-load-web-worker
+if(window!=self)
+  worker_function();

--- a/index.html
+++ b/index.html
@@ -186,7 +186,8 @@
         <a href="https://github.com/dreampuf/graphvizonline">Fork me on GitHub</a>
     </div>
 </div>
-
+<!-- use script tag in case page is loaded from local disk, see https://stackoverflow.com/questions/21408510/chrome-cant-load-web-worker-->
+<script src="full.render.js" type="text/javascript" charset="utf-8"></script>
 <script src="ace/ace.js" type="text/javascript" charset="utf-8"></script>
 <script>
   (function (document) {
@@ -310,7 +311,9 @@
         worker.terminate();
       }
 
-      worker = new Worker("full.render.js");
+      //worker = new Worker("full.render.js");
+	  //Workaround for loading page on local disk from https://stackoverflow.com/questions/21408510/chrome-cant-load-web-worker
+	  worker = new Worker(URL.createObjectURL(new Blob(["("+worker_function.toString()+")()"], {type: 'text/javascript'})))
       worker.addEventListener("message", function (e) {
         if (typeof e.data.error !== "undefined") {
           var event = new CustomEvent("error", {"detail": new Error(e.data.error.message)});

--- a/index.html
+++ b/index.html
@@ -190,6 +190,9 @@
 <script src="full.render.js" type="text/javascript" charset="utf-8"></script>
 <script src="ace/ace.js" type="text/javascript" charset="utf-8"></script>
 <script>
+	//add shortkey to toggle comments with german keyboard layout/language settings
+	ace.edit("editor").commands.bindKey("ctrl-shift-7", "togglecomment");
+	
   (function (document) {
     //http://stackoverflow.com/a/10372280/398634
     window.URL = window.URL || window.webkitURL;


### PR DESCRIPTION
When opening index.html from local disk, Firefox and Chrome prevent loading of the worker script "full.render.js" from local source.
Therefore a workaround from [https://stackoverflow.com/questions/21408510/chrome-cant-load-web-worker](Stackoverflow) was used to enable both local and hosted use