### PR TITLE
feat: Implement compression in share URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,9 +302,7 @@
           var result = JSON.parse(this.responseText);
           shareURLEl.value = result.link;
         } else {
-          shareURLEl.value = longUrl.toString();
-
-          const compressedContent = LZString.compressToEncodedURIComponent(content);
+          const compressedContent = LZString.compressToEncodedURIComponent(editor.getSession().getDocument().getValue());
           const compressedUrl = new URL(location.href);
           compressedUrl.searchParams.append("compressed", compressedContent);
 

--- a/index.html
+++ b/index.html
@@ -305,6 +305,7 @@
           const compressedContent = LZString.compressToEncodedURIComponent(editor.getSession().getDocument().getValue());
           const compressedUrl = new URL(location.href);
           compressedUrl.searchParams.append("compressed", compressedContent);
+          compressedUrl.hash = "";
 
           shareURLEl.value = compressedUrl.toString();
         }

--- a/index.html
+++ b/index.html
@@ -204,6 +204,12 @@
 </div>
 
 <script src="ace/ace.js" type="text/javascript" charset="utf-8"></script>
+<script
+  src="https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.5.0/lz-string.min.js"
+  integrity="sha512-qtX0GLM3qX8rxJN1gyDfcnMFFrKvixfoEOwbBib9VafR5vbChV5LeE5wSI/x+IlCkTY5ZFddFDCCfaVJJNnuKQ=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+></script>
 <script>
   (function (document) {
     //http://stackoverflow.com/a/10372280/398634
@@ -297,6 +303,12 @@
           shareURLEl.value = result.link;
         } else {
           shareURLEl.value = longUrl.toString();
+
+          const compressedContent = LZString.compressToEncodedURIComponent(content);
+          const compressedUrl = new URL(location.href);
+          compressedUrl.searchParams.append("compressed", compressedContent);
+
+          shareURLEl.value = compressedUrl.toString();
         }
       };
     }
@@ -491,6 +503,7 @@
       renderGraph();
     } else if (params.has('compressed')) {
       const compressed = params.get('compressed');
+      editor.getSession().setValue(LZString.decompressFromEncodedURIComponent(compressed));
     } else if (params.has('url')) {
       const url = params.get('url');
       let ok = false;


### PR DESCRIPTION
Did this quick n dirty - If the URL shortener fails, default to compression, using the compression query string that was previously unused.

Import the LZMAString library from a CDN, using SRI to ensure it's correct