### PR TITLE
Support for `?presentation` query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Example: https://dreampuf.github.io/GraphvizOnline/?url=https://gist.githubuserc
 
 Using https://gist.github.com/ allows you to share and version your graph definitions.
 
+## Presentation mode
+
+If you would like to display just the graph and not the graph input, you can add a `?presentation` query param. This can be helpful when generating links with the graph already prefilled.
+
 # How to implement this
 
 - [viz.js](https://github.com/mdaines/viz.js) This repo has compile graphviz(C) to javascript via [emscripten](https://github.com/kripken/emscripten).

--- a/index.html
+++ b/index.html
@@ -10,6 +10,18 @@
             margin: 0 0;
         }
 
+        body.presentation #editor {
+            display: none;
+        }
+
+        body.presentation #options {
+            left: 0;
+        }
+
+        body.presentation #review {
+            left: 0;
+        }
+
         #editor {
             margin: 0;
             position: absolute;
@@ -230,6 +242,10 @@
       shareEl = document.querySelector("#share"),
       shareURLEl = document.querySelector("#shareurl"),
       errorEl = document.querySelector("#error");
+
+    if (new URL(window.location.href).searchParams.has("presentation")) {
+      document.body.classList.add("presentation");
+    }
 
     function show_status(text, hide) {
       hide = hide || 0;

--- a/index.html
+++ b/index.html
@@ -243,10 +243,6 @@
       shareURLEl = document.querySelector("#shareurl"),
       errorEl = document.querySelector("#error");
 
-    if (new URL(window.location.href).searchParams.has("presentation")) {
-      document.body.classList.add("presentation");
-    }
-
     function show_status(text, hide) {
       hide = hide || 0;
       clearTimeout(t_stetus);
@@ -511,6 +507,10 @@
       } else {
         show_error({ message: `invalid engine ${engine} selected` });
       }
+    }
+
+    if (params.has("presentation")) {
+      document.body.classList.add("presentation");
     }
 
     if (params.has('raw')) {


### PR DESCRIPTION
Resolves https://github.com/dreampuf/GraphvizOnline/issues/26

Quick fix for https://github.com/dreampuf/GraphvizOnline/issues/26, our team needs a way to link to the full screen graph as well.

This gets the job done, if there's a `presentation` query param, then hide the editor and make the rendered graph full screen. I'm sure a better solution would be to make the editor expandable and collapsible, but that seems like it would be a bit more involved.

## Without `presentation` query param

<img width="920" alt="Screenshot 2024-07-24 at 3 46 13 PM" src="https://github.com/user-attachments/assets/feaed697-c510-4739-a483-d1cd20d7350b">

## With `presentation` query param

<img width="920" alt="Screenshot 2024-07-24 at 3 46 57 PM" src="https://github.com/user-attachments/assets/76ad1394-db44-447a-ae4b-421271267a09">
