### PR TITLE
feat: Add `?engine` query parameter to url

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,8 +383,13 @@
     }
 
     function updateState() {
-      var content = encodeURIComponent(editor.getSession().getDocument().getValue());
-      history.pushState({"content": content}, "", "#" + content)
+      const updatedUrl = new URL(window.location)
+      // Hash
+      const content = encodeURIComponent(editor.getSession().getDocument().getValue());
+      updatedUrl.hash = content
+      // Search params
+      updatedUrl.searchParams.set("engine", engineEl.value)
+      history.pushState({"content": content}, "", updatedUrl.toString())
     }
 
     function updateOutput(result) {

--- a/index.html
+++ b/index.html
@@ -389,7 +389,7 @@
       updatedUrl.hash = content
       // Search params
       updatedUrl.searchParams.set("engine", engineEl.value)
-      history.pushState({"content": content}, "", updatedUrl.toString())
+      history.pushState({"content": content, "engine": engineEl.value}, "", updatedUrl.toString())
     }
 
     function updateOutput(result) {


### PR DESCRIPTION
When I was using the tool, I had changed the `engine` value and shared the URL with a friend but noticed that the `engine` value had not been added to the URL. I saw that we can manually set the query param so figured I would update to also set this query parameter when changing the select.